### PR TITLE
TH upper bound can be lifted

### DIFF
--- a/th-lift.cabal
+++ b/th-lift.cabal
@@ -24,7 +24,7 @@ Library
     Build-Depends: packedstring == 0.1.*,
                    template-haskell >= 2.2 && < 2.4
   else
-    Build-Depends: template-haskell == 2.4.*
+    Build-Depends: template-haskell >= 2.4 && < 2.6
 
 source-repository head
   type:     git


### PR DESCRIPTION
With the release of GHC 7, TH 2.5 is now on the market. Luckily, it doesn't seem like the code needs any changes to compile on it: the cabal file just needs to be told that it's possible.
