### PR TITLE
Raise TH version upper bound for ghc 7.2 rc1, add FlexibleInstance for ghc 7.2 rc1

### DIFF
--- a/src/Language/Haskell/TH/Lift.hs
+++ b/src/Language/Haskell/TH/Lift.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, TemplateHaskell, MagicHash, TypeSynonymInstances #-}
+{-# LANGUAGE CPP, TemplateHaskell, MagicHash, TypeSynonymInstances, FlexibleInstances #-}
 module Language.Haskell.TH.Lift (deriveLift, deriveLiftMany, deriveLift', deriveLiftMany', Lift(..)) where
 
 #if !(MIN_VERSION_template_haskell(2,4,0))

--- a/th-lift.cabal
+++ b/th-lift.cabal
@@ -16,7 +16,7 @@ Extra-source-files: BSD3, GPL-2, Changelog, t/Foo.hs, t/Test.hs
 
 Library
   Exposed-modules: Language.Haskell.TH.Lift
-  Extensions:      CPP, TemplateHaskell, MagicHash, TypeSynonymInstances
+  Extensions:      CPP, TemplateHaskell, MagicHash, TypeSynonymInstances, FlexibleInstances
   Hs-Source-Dirs:  src
   Build-Depends:   base >= 3 && < 5
 
@@ -24,7 +24,7 @@ Library
     Build-Depends: packedstring == 0.1.*,
                    template-haskell >= 2.2 && < 2.4
   else
-    Build-Depends: template-haskell >= 2.4 && < 2.6
+    Build-Depends: template-haskell >= 2.4 && < 2.7
 
 source-repository head
   type:     git


### PR DESCRIPTION
Built with ghc 7.2rc1, 7.0.4 and 6.12.3 on Gentoo Linux 3.0 amd64.
