### PR TITLE
Compile with ghc-7.9.x

### DIFF
--- a/th-lift.cabal
+++ b/th-lift.cabal
@@ -25,7 +25,7 @@ Library
     Build-Depends: packedstring == 0.1.*,
                    template-haskell >= 2.2 && < 2.4
   else
-    Build-Depends: template-haskell >= 2.4 && < 2.10
+    Build-Depends: template-haskell >= 2.4 && < 2.11
 
 source-repository head
   type:     git


### PR DESCRIPTION
The next version of GHC/template-haskell makes `Pred` a synonym for `Type` (to support ConstraintKinds) and makes the integers in the `Name` type lifted. This patch gets th-lift to compile with GHC HEAD, while (hopefully) not sacrificing other compatibility. I've tested on GHC 7.8.3, but not other versions.
