### PR TITLE
Support template-haskell 2.17, plus unlifted fix.

### DIFF
--- a/th-lift.cabal
+++ b/th-lift.cabal
@@ -45,8 +45,8 @@ Library
   Hs-Source-Dirs:   src
   Build-Depends:    base              >= 4.3  && < 5,
                     ghc-prim,
-                    th-abstraction   >= 0.2.3 && < 0.4,
-                    template-haskell >= 2.5   && < 2.17
+                    th-abstraction   >= 0.2.3 && < 0.5,
+                    template-haskell >= 2.5   && < 2.18
   ghc-options:      -Wall
 
 Test-Suite test


### PR DESCRIPTION
Most changes are to use the new `Code` newtype (https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3358).

Also, while I was in there I took the opportunity to fix #43.

Note that I had to use your [`explicit-specificity`](https://github.com/glguy/th-abstraction/pull/83) branch of `th-abstraction` to build, since it's a dependency.  Bounds adjusted accordingly.