### PR TITLE
Allow building with template-haskell-2.17.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [next] - ????-??-??
+
+* Allow building with `template-haskell-2.17.0.0` (GHC 9.0).
+* Make `deriveLift` work for unlifted newtypes.
+
 ## [0.8.1] - 2019-12-06
 
 * Support GHC 8.10/`template-haskell-2.16`.

--- a/src/Language/Haskell/TH/Lift/Internal.hs
+++ b/src/Language/Haskell/TH/Lift/Internal.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+#if __GLASGOW_HASKELL__ >= 706
+{-# LANGUAGE PolyKinds #-}
+#endif
+
+-- | Helper functions used in code that "Language.Haskell.TH.Lift" generates.
+--
+-- Note: this is an internal module, and as such, the API presented here is not
+-- guaranteed to be stable, even between minor releases of this library.
+module Language.Haskell.TH.Lift.Internal where
+
+#if MIN_VERSION_template_haskell(2,16,0)
+import GHC.Exts (RuntimeRep, TYPE)
+#endif
+
+import Language.Haskell.TH.Syntax
+
+-- | A type-restricted version of 'error' that ensures 'makeLift' always
+-- returns a value of type @q 'Exp'@ (where @q@ is an instance of 'Quote'),
+-- even when used on an empty datatype.
+#if MIN_VERSION_template_haskell(2,17,0)
+errorQuoteExp :: Quote q => String -> q Exp
+#else
+errorQuoteExp ::            String -> Q Exp
+#endif
+errorQuoteExp = error
+
+-- | This is a cargo-culted version of @unsafeSpliceCoerce@ from the
+-- @th-compat@ library, which has been copied here to avoid incurring a library
+-- dependency.
+--
+-- Only available when built with @template-haskell-2.9.0.0@ or later.
+#if MIN_VERSION_template_haskell(2,17,0)
+unsafeSpliceCoerce :: forall (r :: RuntimeRep) (a :: TYPE r) m. Quote m => m Exp -> Code m a
+unsafeSpliceCoerce = unsafeCodeCoerce
+#elif MIN_VERSION_template_haskell(2,16,0)
+unsafeSpliceCoerce :: forall (r :: RuntimeRep) (a :: TYPE r). Q Exp -> Q (TExp a)
+unsafeSpliceCoerce = unsafeTExpCoerce
+#elif MIN_VERSION_template_haskell(2,9,0)
+unsafeSpliceCoerce :: forall a. Q Exp -> Q (TExp a)
+unsafeSpliceCoerce = unsafeTExpCoerce
+#endif

--- a/th-lift.cabal
+++ b/th-lift.cabal
@@ -37,6 +37,7 @@ source-repository head
 Library
   Default-Language: Haskell2010
   Exposed-modules:  Language.Haskell.TH.Lift
+                    Language.Haskell.TH.Lift.Internal
   Other-Extensions: CPP,  MagicHash, TypeSynonymInstances, FlexibleInstances
   if impl(ghc >= 8.0)
     Other-Extensions: TemplateHaskellQuotes
@@ -45,8 +46,8 @@ Library
   Hs-Source-Dirs:   src
   Build-Depends:    base              >= 4.3  && < 5,
                     ghc-prim,
-                    th-abstraction   >= 0.2.3 && < 0.4,
-                    template-haskell >= 2.5   && < 2.17
+                    th-abstraction   >= 0.2.3 && < 0.5,
+                    template-haskell >= 2.5   && < 2.18
   ghc-options:      -Wall
 
 Test-Suite test


### PR DESCRIPTION
To minimize the amount of CPP that I had to use, I copied over `unsafeSpliceCoerce` from `th-compat` and put it in a new `Language.Haskell.TH.Lift.Internal` module. Since `unsafeSpliceCoerce` appears in generated code, I decided to export `Language.Haskell.TH.Lift.Internal`, but with an explicit caveat that it is not a part of the public API.

While I was in town, I also took the opportunity to fix #43.