### PR TITLE
Support building with `template-haskell-2.22.1`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,6 +28,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.12.20241014
+            compilerKind: ghc
+            compilerVersion: 9.12.20241014
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.10.1
             compilerKind: ghc
             compilerVersion: 9.10.1
@@ -122,7 +127,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -151,6 +156,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -204,6 +221,9 @@ jobs:
           package th-lift
             ghc-options: -Werror
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(th-lift)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [next] - ????.??.??
 
+* Support building with `template-haskell-2.22.1`.
 * Drop support for pre-8.0 versions of GHC.
 
 ## [0.8.4] - 2023.08.01

--- a/src/Language/Haskell/TH/Lift.hs
+++ b/src/Language/Haskell/TH/Lift.hs
@@ -212,29 +212,30 @@ typeDataError dataName = fail
   . showString "‘, which is a ‘type data‘ declaration"
   $ ""
 
+#if !MIN_VERSION_template_haskell(2,22,1)
 instance Lift Name where
   lift (Name occName nameFlavour) = [| Name occName nameFlavour |]
-#if MIN_VERSION_template_haskell(2,16,0)
+# if MIN_VERSION_template_haskell(2,16,0)
   liftTyped = unsafeSpliceCoerce . lift
-#endif
+# endif
 
 instance Lift OccName where
   lift n = [| mkOccName |] `appE` lift (occString n)
-#if MIN_VERSION_template_haskell(2,16,0)
+# if MIN_VERSION_template_haskell(2,16,0)
   liftTyped = unsafeSpliceCoerce . lift
-#endif
+# endif
 
 instance Lift PkgName where
   lift n = [| mkPkgName |] `appE` lift (pkgString n)
-#if MIN_VERSION_template_haskell(2,16,0)
+# if MIN_VERSION_template_haskell(2,16,0)
   liftTyped = unsafeSpliceCoerce . lift
-#endif
+# endif
 
 instance Lift ModName where
   lift n = [| mkModName |] `appE` lift (modString n)
-#if MIN_VERSION_template_haskell(2,16,0)
+# if MIN_VERSION_template_haskell(2,16,0)
   liftTyped = unsafeSpliceCoerce . lift
-#endif
+# endif
 
 instance Lift NameFlavour where
   lift NameS = [| NameS |]
@@ -243,17 +244,18 @@ instance Lift NameFlavour where
   lift (NameL i) = [| NameL i |]
   lift (NameG nameSpace' pkgName modnam)
    = [| NameG nameSpace' pkgName modnam |]
-#if MIN_VERSION_template_haskell(2,16,0)
+# if MIN_VERSION_template_haskell(2,16,0)
   liftTyped = unsafeSpliceCoerce . lift
-#endif
+# endif
 
 instance Lift NameSpace where
   lift VarName = [| VarName |]
   lift DataName = [| DataName |]
   lift TcClsName = [| TcClsName |]
-#if MIN_VERSION_template_haskell(2,21,0)
+# if MIN_VERSION_template_haskell(2,21,0)
   lift (FldName parent) = [| FldName parent |]
-#endif
-#if MIN_VERSION_template_haskell(2,16,0)
+# endif
+# if MIN_VERSION_template_haskell(2,16,0)
   liftTyped = unsafeSpliceCoerce . lift
+# endif
 #endif

--- a/th-lift.cabal
+++ b/th-lift.cabal
@@ -26,7 +26,7 @@ Description:
     old versions of their respective libraries, as the same @Lift@ instances
     are also present upstream on newer versions.
 Category:           Language
-Tested-With:        GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.5, GHC==8.8.4, GHC==8.10.7, GHC==9.0.2, GHC==9.2.8, GHC==9.4.8, GHC==9.6.6, GHC==9.8.2, GHC==9.10.1
+Tested-With:        GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.5, GHC==8.8.4, GHC==8.10.7, GHC==9.0.2, GHC==9.2.8, GHC==9.4.8, GHC==9.6.6, GHC==9.8.2, GHC==9.10.1, GHC==9.12.1
 build-type:         Simple
 Extra-source-files: CHANGELOG.md
 


### PR DESCRIPTION
`template-haskell-2.22.1` adds `Lift` instances for `Name`, `OccName`, and related data types. `th-lift` defines orphan `Lift` instances for these data types, however, which results in instance collision. This guards the orphan instances with CPP to avoid compilation failures.